### PR TITLE
Update Cassiopeia.cs

### DIFF
--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -97,6 +97,7 @@ namespace SixAIO.Champions
                 TargetSelect = (mode) => {
                     var targets = SpellRSemiAuto.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
+                                                      x.IsObject(ObjectTypeFlag.AIHeroClient) &&
                                                       !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
 
                     return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
@@ -114,6 +115,7 @@ namespace SixAIO.Champions
                 TargetSelect = (mode) => {
                     var targets = SpellRSemiAuto.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
+                                                      x.IsObject(ObjectTypeFlag.AIHeroClient) &&
                                                       !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
 
                     return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;

--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -120,7 +120,7 @@ namespace SixAIO.Champions
                                                       x.IsObject(ObjectTypeFlag.AIHeroClient) &&
                                                       !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
 
-                    return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
+                    return (targets != null && targets.Count() >= SemiAutoRMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
                 }
             };
         }
@@ -225,6 +225,12 @@ namespace SixAIO.Champions
             set => RSettings.GetItem<Counter>("Minimum enemies facing for R").Value = value;
         }
 
+        private int SemiAutoRMinimumEnemiesCount
+        {
+            get => RSettings.GetItem<Counter>("Minimum enemies facing for semi-auto R").Value;
+            set => RSettings.GetItem<Counter>("Minimum enemies facing for semi-auto R").Value = value;
+        }
+
         internal override void InitializeMenu()
         {
             MenuManager.AddTab(new Tab($"SIXAIO - {nameof(Cassiopeia)}"));
@@ -249,11 +255,12 @@ namespace SixAIO.Champions
 
             RSettings.AddItem(new Switch() { Title = "Use R", IsOn = true });
             RSettings.AddItem(new ModeDisplay() { Title = "R HitChance", ModeNames = Enum.GetNames(typeof(Prediction.MenuSelected.HitChance)).ToList(), SelectedModeName = "High" });
+            RSettings.AddItem(new Counter() { Title = "Minimum enemies facing for R", MinValue = 1, MaxValue = 5, Value = 3 });
 
             RSettings.AddItem(new Switch() { Title = "Use Semi Auto R", IsOn = true });
             RSettings.AddItem(new KeyBinding() { Title = "Semi Auto R Key", SelectedKey = Keys.T });
             RSettings.AddItem(new ModeDisplay() { Title = "Semi Auto R HitChance", ModeNames = Enum.GetNames(typeof(Prediction.MenuSelected.HitChance)).ToList(), SelectedModeName = "High" });
-            RSettings.AddItem(new Counter() { Title = "Minimum enemies facing for R", MinValue = 1, MaxValue = 5, Value = 1 });
+            RSettings.AddItem(new Counter() { Title = "Minimum enemies facing for semi-auto R", MinValue = 1, MaxValue = 5, Value = 1 });
 
             MenuTab.AddDrawOptions(SpellSlot.Q, SpellSlot.W, SpellSlot.E, SpellSlot.R);
 

--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -57,6 +57,9 @@ namespace SixAIO.Champions
                 IsEnabled = () => UseE,
                 TargetSelect = (mode) =>
                 {
+                    if(UseELasthit && mode == Orbwalker.OrbWalkingModeType.LastHit)
+                        return SpellE.GetTargets(mode, x => x.PredictHealth(150) <= GetEDamage(x, SpellE.SpellClass)).OrderBy(IsPoisoned).ThenBy(x => x.EffectiveMagicHealth).FirstOrDefault();
+
                     var target = SpellE.GetTargets(mode).OrderBy(IsPoisoned).ThenBy(x => x.EffectiveMagicHealth).FirstOrDefault();
                     if (UseELasthit)
                     {

--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -58,7 +58,9 @@ namespace SixAIO.Champions
                 TargetSelect = (mode) =>
                 {
                     if (UseELasthit && mode == Orbwalker.OrbWalkingModeType.LastHit)
+                    {
                         return SpellE.GetTargets(mode, x => x.PredictHealth(150) <= GetEDamage(x, SpellE.SpellClass)).OrderBy(IsPoisoned).ThenBy(x => x.EffectiveMagicHealth).FirstOrDefault();
+                    }
 
                     var target = SpellE.GetTargets(mode).OrderBy(IsPoisoned).ThenBy(x => x.EffectiveMagicHealth).FirstOrDefault();
                     if (UseELasthit)

--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -94,10 +94,13 @@ namespace SixAIO.Champions
                 Radius = () => 80,
                 Delay = () => 0.5f,
                 IsEnabled = () => UseR,
-                TargetSelect = (mode) => SpellR.GetTargets(mode, x =>
+                TargetSelect = (mode) => {
+                    var targets = SpellRSemiAuto.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
-                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false))
-                                                .FirstOrDefault()
+                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
+
+                    return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
+                }
             };
             SpellRSemiAuto = new Spell(CastSlot.R, SpellSlot.R)
             {
@@ -108,10 +111,13 @@ namespace SixAIO.Champions
                 Radius = () => 80,
                 Delay = () => 0.5f,
                 IsEnabled = () => UseSemiAutoR,
-                TargetSelect = (mode) => SpellRSemiAuto.GetTargets(mode, x =>
+                TargetSelect = (mode) => {
+                    var targets = SpellRSemiAuto.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
-                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false))
-                                                .FirstOrDefault()
+                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
+
+                    return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
+                }
             };
         }
 
@@ -209,6 +215,12 @@ namespace SixAIO.Champions
 
         public Keys DisableAAKey => MenuTab.GetItem<KeyBinding>("Disable AA Key").SelectedKey;
 
+        private int RMinimumEnemiesCount
+        {
+            get => RSettings.GetItem<Counter>("Minimum enemies facing for R").Value;
+            set => RSettings.GetItem<Counter>("Minimum enemies facing for R").Value = value;
+        }
+
         internal override void InitializeMenu()
         {
             MenuManager.AddTab(new Tab($"SIXAIO - {nameof(Cassiopeia)}"));
@@ -237,7 +249,7 @@ namespace SixAIO.Champions
             RSettings.AddItem(new Switch() { Title = "Use Semi Auto R", IsOn = true });
             RSettings.AddItem(new KeyBinding() { Title = "Semi Auto R Key", SelectedKey = Keys.T });
             RSettings.AddItem(new ModeDisplay() { Title = "Semi Auto R HitChance", ModeNames = Enum.GetNames(typeof(Prediction.MenuSelected.HitChance)).ToList(), SelectedModeName = "High" });
-
+            RSettings.AddItem(new Counter() { Title = "Minimum enemies facing for R", MinValue = 1, MaxValue = 5, Value = 1 });
 
             MenuTab.AddDrawOptions(SpellSlot.Q, SpellSlot.W, SpellSlot.E, SpellSlot.R);
 

--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -57,10 +57,8 @@ namespace SixAIO.Champions
                 IsEnabled = () => UseE,
                 TargetSelect = (mode) =>
                 {
-                    if(UseELasthit && mode == Orbwalker.OrbWalkingModeType.LastHit)
-                    {
+                    if (UseELasthit && mode == Orbwalker.OrbWalkingModeType.LastHit)
                         return SpellE.GetTargets(mode, x => x.PredictHealth(150) <= GetEDamage(x, SpellE.SpellClass)).OrderBy(IsPoisoned).ThenBy(x => x.EffectiveMagicHealth).FirstOrDefault();
-                    }
 
                     var target = SpellE.GetTargets(mode).OrderBy(IsPoisoned).ThenBy(x => x.EffectiveMagicHealth).FirstOrDefault();
                     if (UseELasthit)
@@ -96,10 +94,13 @@ namespace SixAIO.Champions
                 Radius = () => 80,
                 Delay = () => 0.5f,
                 IsEnabled = () => UseR,
-                TargetSelect = (mode) => SpellR.GetTargets(mode, x =>
+                TargetSelect = (mode) => {
+                    var targets = SpellRSemiAuto.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
-                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false))
-                                                .FirstOrDefault()
+                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
+
+                    return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
+                }
             };
             SpellRSemiAuto = new Spell(CastSlot.R, SpellSlot.R)
             {
@@ -110,10 +111,13 @@ namespace SixAIO.Champions
                 Radius = () => 80,
                 Delay = () => 0.5f,
                 IsEnabled = () => UseSemiAutoR,
-                TargetSelect = (mode) => SpellRSemiAuto.GetTargets(mode, x =>
+                TargetSelect = (mode) => {
+                    var targets = SpellRSemiAuto.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
-                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false))
-                                                .FirstOrDefault()
+                                                      !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));
+
+                    return (targets != null && targets.Count() >= RMinimumEnemiesCount) ? targets.FirstOrDefault() : null;
+                }
             };
         }
 
@@ -211,6 +215,12 @@ namespace SixAIO.Champions
 
         public Keys DisableAAKey => MenuTab.GetItem<KeyBinding>("Disable AA Key").SelectedKey;
 
+        private int RMinimumEnemiesCount
+        {
+            get => RSettings.GetItem<Counter>("Minimum enemies facing for R").Value;
+            set => RSettings.GetItem<Counter>("Minimum enemies facing for R").Value = value;
+        }
+
         internal override void InitializeMenu()
         {
             MenuManager.AddTab(new Tab($"SIXAIO - {nameof(Cassiopeia)}"));
@@ -239,7 +249,7 @@ namespace SixAIO.Champions
             RSettings.AddItem(new Switch() { Title = "Use Semi Auto R", IsOn = true });
             RSettings.AddItem(new KeyBinding() { Title = "Semi Auto R Key", SelectedKey = Keys.T });
             RSettings.AddItem(new ModeDisplay() { Title = "Semi Auto R HitChance", ModeNames = Enum.GetNames(typeof(Prediction.MenuSelected.HitChance)).ToList(), SelectedModeName = "High" });
-
+            RSettings.AddItem(new Counter() { Title = "Minimum enemies facing for R", MinValue = 1, MaxValue = 5, Value = 1 });
 
             MenuTab.AddDrawOptions(SpellSlot.Q, SpellSlot.W, SpellSlot.E, SpellSlot.R);
 

--- a/src/SixAIO.NET/Champions/Cassiopeia.cs
+++ b/src/SixAIO.NET/Champions/Cassiopeia.cs
@@ -97,7 +97,7 @@ namespace SixAIO.Champions
                 Delay = () => 0.5f,
                 IsEnabled = () => UseR,
                 TargetSelect = (mode) => {
-                    var targets = SpellRSemiAuto.GetTargets(mode, x =>
+                    var targets = SpellR.GetTargets(mode, x =>
                                                       x.IsFacing(UnitManager.MyChampion) &&
                                                       x.IsObject(ObjectTypeFlag.AIHeroClient) &&
                                                       !TargetSelector.IsInvulnerable(x, Oasys.Common.Logic.DamageType.Magical, false));

--- a/src/SixAIO.NET/Champions/Soraka.cs
+++ b/src/SixAIO.NET/Champions/Soraka.cs
@@ -32,7 +32,7 @@ namespace SixAIO.Champions
                 ShouldDraw = () => DrawWRange,
                 DrawColor = () => DrawWColor,
                 IsTargetted = () => true,
-                IsEnabled = () => UseW,
+                IsEnabled = () => UseW && UnitManager.MyChampion.HealthPercent > WSelfHealthPercent,
                 Range = () => 550,
                 TargetSelect = (mode) => UnitManager.AllyChampions.Where(x => !x.IsTargetDummy && !x.IsMe)
                                         .OrderByDescending(x => WSettings.GetItem<Counter>("Heal Ally Prio- " + x?.ModelName)?.Value)
@@ -77,8 +77,8 @@ namespace SixAIO.Champions
 
         private int WHealthPercent
         {
-            get => WSettings.GetItem<Counter>("Heal below health percent").Value;
-            set => WSettings.GetItem<Counter>("Heal below health percent").Value = value;
+            get => WSettings.GetItem<Counter>("Heal allies below health percent").Value;
+            set => WSettings.GetItem<Counter>("Heal allies below health percent").Value = value;
         }
 
         private int RHealthPercent
@@ -93,6 +93,12 @@ namespace SixAIO.Champions
             set => RSettings.GetItem<Counter>("Allies to heal").Value = value;
         }
 
+        private int WSelfHealthPercent
+        {
+            get => WSettings.GetItem<Counter>("Do not heal if self-health below").Value;
+            set => WSettings.GetItem<Counter>("Do not heal if self-health below").Value = value;
+        }
+
         internal override void InitializeMenu()
         {
             MenuManager.AddTab(new Tab($"SIXAIO - {nameof(Soraka)}"));
@@ -104,8 +110,9 @@ namespace SixAIO.Champions
             QSettings.AddItem(new Switch() { Title = "Use Q", IsOn = true });
             QSettings.AddItem(new ModeDisplay() { Title = "Q HitChance", ModeNames = Enum.GetNames(typeof(Prediction.MenuSelected.HitChance)).ToList(), SelectedModeName = "High" });
 
-            WSettings.AddItem(new Switch() { Title = "Use W", IsOn = true });
-            WSettings.AddItem(new Counter() { Title = "Heal below health percent", MinValue = 0, MaxValue = 100, Value = 40, ValueFrequency = 5 });
+            WSettings.AddItem(new Switch() { Title = "Use W", IsOn = true });            
+            WSettings.AddItem(new Counter() { Title = "Do not heal if self-health below", MinValue = 0, MaxValue = 100, Value = 40, ValueFrequency = 5 });
+            WSettings.AddItem(new Counter() { Title = "Heal allies below health percent", MinValue = 0, MaxValue = 100, Value = 40, ValueFrequency = 5 });
             WSettings.AddItem(new InfoDisplay() { Title = "---Allies to heal - 0 to disable---" });
             foreach (var allyChampion in UnitManager.AllyChampions.Where(x => !x.IsTargetDummy && !x.IsMe))
             {


### PR DESCRIPTION
2055f41 Added an option to set the minimum amount of enemies that should be facing Cassiopeia when casting her ultimate
6d9cc35 Fix for previous commit
9fab883 Split the option in two : Minimum enemies for R and minimum enemies for semi-auto R, quite useful in teamfights